### PR TITLE
Patch html-to-image dependency

### DIFF
--- a/patches/html-to-image.patch
+++ b/patches/html-to-image.patch
@@ -1,0 +1,39 @@
+diff --git a/es/embed-webfonts.js b/es/embed-webfonts.js
+index f6b0d96829c8a3301c142cacd07079e85b1f64fd..9590763a007e4d334a69673fb94eef0930fe35ea 100644
+--- a/es/embed-webfonts.js
++++ b/es/embed-webfonts.js
+@@ -175,7 +175,7 @@ export async function getWebFontCSS(node, options) {
+     const rules = await parseWebFontRules(node, options);
+     const usedFonts = getUsedFonts(node);
+     const cssTexts = await Promise.all(rules
+-        .filter((rule) => usedFonts.has(normalizeFontFamily(rule.style.fontFamily)))
++        .filter((rule) => usedFonts.has(normalizeFontFamily(rule.style.fontFamily || rule.style.getPropertyValue('fontFamily'))))
+         .map((rule) => {
+         const baseUrl = rule.parentStyleSheet
+             ? rule.parentStyleSheet.href
+diff --git a/lib/embed-webfonts.js b/lib/embed-webfonts.js
+index c91538bd9c3afa63326a91267fb7b5b9c999cccd..bde5e1c7cb64687ec0dd583795d0185e50bfa450 100644
+--- a/lib/embed-webfonts.js
++++ b/lib/embed-webfonts.js
+@@ -262,7 +262,7 @@ function getWebFontCSS(node, options) {
+                     usedFonts = getUsedFonts(node);
+                     return [4 /*yield*/, Promise.all(rules
+                             .filter(function (rule) {
+-                            return usedFonts.has(normalizeFontFamily(rule.style.fontFamily));
++                            return usedFonts.has(normalizeFontFamily(rule.style.fontFamily || rule.style.getPropertyValue('fontFamily')));
+                         })
+                             .map(function (rule) {
+                             var baseUrl = rule.parentStyleSheet
+diff --git a/src/embed-webfonts.ts b/src/embed-webfonts.ts
+index a84a699d37aeaaea19b9b31e0e98710f1e30da3c..bca861325b6ebc78e4e612ac7d5240ed91162204 100644
+--- a/src/embed-webfonts.ts
++++ b/src/embed-webfonts.ts
+@@ -234,7 +234,7 @@ export async function getWebFontCSS<T extends HTMLElement>(
+   const cssTexts = await Promise.all(
+     rules
+       .filter((rule) =>
+-        usedFonts.has(normalizeFontFamily(rule.style.fontFamily)),
++        usedFonts.has(normalizeFontFamily(rule.style.fontFamily || rule.style.getPropertyValue('fontFamily'))),
+       )
+       .map((rule) => {
+         const baseUrl = rule.parentStyleSheet

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  html-to-image:
+    hash: f56d67e79773a32bcbb840433e616591ae185de0c29ca1b693a932926e5fbddc
+    path: patches/html-to-image.patch
+
 importers:
 
   .:
@@ -94,7 +99,7 @@ importers:
         version: 0.44.1(@neondatabase/serverless@1.0.0)(@types/pg@8.15.2)(kysely@0.28.2)(pg@8.16.0)(postgres@3.4.7)
       html-to-image:
         specifier: ^1.11.13
-        version: 1.11.13
+        version: 1.11.13(patch_hash=f56d67e79773a32bcbb840433e616591ae185de0c29ca1b693a932926e5fbddc)
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.1.0)
@@ -6581,7 +6586,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  html-to-image@1.11.13: {}
+  html-to-image@1.11.13(patch_hash=f56d67e79773a32bcbb840433e616591ae185de0c29ca1b693a932926e5fbddc): {}
 
   html-to-text@9.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+patchedDependencies:
+  # This patches bug 532 in html-to-image: https://github.com/bubkoo/html-to-image/issues/532
+  # There is a PR open to fix this, but it has not been merged yet: https://github.com/bubkoo/html-to-image/pull/547
+  html-to-image: patches/html-to-image.patch


### PR DESCRIPTION
This PR fixes [Issue 2](https://github.com/kelvin-mai/daggerheartbrews.com/issues/2) by adding a pnpm-patch to the html-to-image dependency for its [bug 532](https://github.com/bubkoo/html-to-image/issues/532).