### PR TITLE
Fixing two issues: A typo and a readability issue. 

### DIFF
--- a/src/components/game-master/index.tsx
+++ b/src/components/game-master/index.tsx
@@ -291,7 +291,7 @@ export const GameMasterBattle = () => {
     { number: '+1', description: 'Using an adversary from a lower tier' },
     {
       number: '+1',
-      description: 'Not using Hords, Leaders, Bruisers or Solos',
+      description: 'Not using Hordes, Leaders, Bruisers or Solos',
     },
     { number: '+2', description: 'Intending a more dangerous or longer fight' },
   ];


### PR DESCRIPTION
Addressing two issues here.

### Typo
For the following entry in the table Adjusting Battle Points:

_Using an adversary from a lower tier_

It informs the GM/User that you are supposed to decrement 1 point for using an adversary of a lower tier. This is incorrect and likely a typo. Small fix to increment 1 point for the using a lower tier adversary.

### Readability

The following entry in the table Adjusting Battle Points feels a little ambiguous:

_Adding 1d4 damage to all adversaries_

One could read it as either:

- Damage done to adversaries applies an additional 1d4
- Damage done by adversaries applies an additional 1d4

In an effort for a little clarity, I've updated it to the following:

_Add 1d4 (or a static +2) to all adversary damage rolls_
    
The text is clear who gets the modifier die. I've also added in the optional info about a static value.

